### PR TITLE
Fixes UnitDescription for single Values

### DIFF
--- a/Sources/Physical/Core/Physical/Description.swift
+++ b/Sources/Physical/Core/Physical/Description.swift
@@ -23,85 +23,8 @@ extension Physical: CustomStringConvertible, CustomDebugStringConvertible {
 			return numericalPart.trimmingCharacters(in: .whitespaces)
 		}
 		
-		var unitPart = ""
-		var firstTerm = true
-		
-		let sortedUnits = units.sorted(by: { a, b in a.key.symbol < b.key.symbol })
-		let numeratorUnits = sortedUnits.filter { (_, v) in v.1.isPositive }
-		
-		for (_, (unit, exponent)) in numeratorUnits {
-			if !firstTerm {
-				unitPart += " "
-			}
-			else {
-				firstTerm = false
-			}
-			
-			let symbol = unit.symbol.contains("/") ? "(\(unit.symbol))" : "\(unit.symbol)"
-			
-			switch exponent {
-				case let .integer(e):
-					switch e {
-						case 0: break
-						case 1: unitPart += "\(unit.symbol)"
-						default: unitPart += symbol + e.drawnExponent
-					}
-					
-				case .fraction(_, _):
-					unitPart += symbol + "^(\(exponent))"
-					
-				case .real(_):
-					let expString = "\(exponent)"
-					
-					if expString != "1" {
-						unitPart += symbol + "^\(exponent)"
-					}
-					else {
-						unitPart += symbol
-					}
-			}
-		}
-		
-		var alreadyDrawnDivisor = false
-		firstTerm = true
-		
-		for (_, (unit, exponent)) in sortedUnits where !exponent.isPositive {
-			if !alreadyDrawnDivisor {
-				unitPart += " / "
-				alreadyDrawnDivisor = true
-			}
-			
-			if !firstTerm {
-				unitPart += " "
-			}
-			else {
-				firstTerm = false
-			}
-			
-			let symbol = unit.symbol.contains("/") ? "(\(unit.symbol))" : "\(unit.symbol)"
-			
-			switch exponent {
-				case let .integer(e):
-					switch e {
-						case -1: unitPart += "\(unit.symbol)"
-						default: unitPart += symbol + abs(e).drawnExponent
-					}
-					
-				case .fraction(_, _):
-					unitPart += symbol + "^(\(abs(exponent)))"
-					
-				case .real(_):
-					let expString = "\(abs(exponent))"
-					
-					if expString == "1" {
-						unitPart += symbol
-					}
-					else {
-						unitPart += symbol + "^\(expString)"
-					}
-			}
-		}
-		
+    let unitPart = self.unitDescription
+
 		if let values = values {
 			let numbersString = "[\(values.map({ numberString($0) }).joined(separator: ", "))]"
 			return "\(numbersString) \(unitPart)".trimmingCharacters(in: .whitespaces)
@@ -149,10 +72,88 @@ extension Physical: CustomStringConvertible, CustomDebugStringConvertible {
 		
 		return out.joined(separator: "\n")
 	}
-	
+
 	public var unitDescription: String {
-		// TODO: fix this terrible hack:
-		description.components(separatedBy: "]").last!.trimmingCharacters(in: .whitespaces)
+    var unitPart = ""
+    var firstTerm = true
+
+    let sortedUnits = units.sorted(by: { a, b in a.key.symbol < b.key.symbol })
+    let numeratorUnits = sortedUnits.filter { (_, v) in v.1.isPositive }
+
+    for (_, (unit, exponent)) in numeratorUnits {
+      if !firstTerm {
+        unitPart += " "
+      }
+      else {
+        firstTerm = false
+      }
+
+      let symbol = unit.symbol.contains("/") ? "(\(unit.symbol))" : "\(unit.symbol)"
+
+      switch exponent {
+      case let .integer(e):
+        switch e {
+        case 0: break
+        case 1: unitPart += "\(unit.symbol)"
+        default: unitPart += symbol + e.drawnExponent
+        }
+
+      case .fraction(_, _):
+        unitPart += symbol + "^(\(exponent))"
+
+      case .real(_):
+        let expString = "\(exponent)"
+
+        if expString != "1" {
+          unitPart += symbol + "^\(exponent)"
+        }
+        else {
+          unitPart += symbol
+        }
+      }
+    }
+
+    var alreadyDrawnDivisor = false
+    firstTerm = true
+
+    for (_, (unit, exponent)) in sortedUnits where !exponent.isPositive {
+      if !alreadyDrawnDivisor {
+        unitPart += " / "
+        alreadyDrawnDivisor = true
+      }
+
+      if !firstTerm {
+        unitPart += " "
+      }
+      else {
+        firstTerm = false
+      }
+
+      let symbol = unit.symbol.contains("/") ? "(\(unit.symbol))" : "\(unit.symbol)"
+
+      switch exponent {
+      case let .integer(e):
+        switch e {
+        case -1: unitPart += "\(unit.symbol)"
+        default: unitPart += symbol + abs(e).drawnExponent
+        }
+
+      case .fraction(_, _):
+        unitPart += symbol + "^(\(abs(exponent)))"
+
+      case .real(_):
+        let expString = "\(abs(exponent))"
+
+        if expString == "1" {
+          unitPart += symbol
+        }
+        else {
+          unitPart += symbol + "^\(expString)"
+        }
+      }
+    }
+
+    return unitPart
 	}
 
 	public var tagDescription: String {

--- a/Tests/PhysicalTests/PhysicalTests.swift
+++ b/Tests/PhysicalTests/PhysicalTests.swift
@@ -471,4 +471,38 @@ final class PhysicalTests: XCTestCase {
 		XCTAssertEqual(volumeOneMoleNaCl, 4.48e-29.m³ )
 		XCTAssertEqual(ionDistance, 2.82e-10.m )
 	}
+
+  // Reproduces Issue #2
+  func testDescription() {
+    var length = 5.meters
+    XCTAssertEqual(length.description, "5 m")
+    XCTAssertEqual(length.unitDescription, "m")
+    XCTAssertEqual(length.dimensionalDescription, "L")
+    length = 14.millimeters
+    XCTAssertEqual(length.description, "14 mm")
+    XCTAssertEqual(length.unitDescription, "mm")
+    XCTAssertEqual(length.dimensionalDescription, "L")
+    length = 8.feet
+    XCTAssertEqual(length.description, "8 ft")
+    XCTAssertEqual(length.unitDescription, "ft")
+    XCTAssertEqual(length.dimensionalDescription, "L")
+
+    var area = 2.feet.feet
+    XCTAssertEqual(area.description, "2 ft²")
+    XCTAssertEqual(area.unitDescription, "ft²")
+    XCTAssertEqual(area.dimensionalDescription, "L²")
+    area = 6.meters(2)
+    XCTAssertEqual(area.description, "6 m²")
+    XCTAssertEqual(area.unitDescription, "m²")
+    XCTAssertEqual(area.dimensionalDescription, "L²")
+
+    var lengthArray = [13, 19].kilometers
+    XCTAssertEqual(lengthArray.description, "[13, 19] km")
+    XCTAssertEqual(lengthArray.unitDescription, "km")
+    XCTAssertEqual(lengthArray.dimensionalDescription, "L")
+    lengthArray = [20, 21].miles
+    XCTAssertEqual(lengthArray.description, "[20, 21] mi")
+    XCTAssertEqual(lengthArray.unitDescription, "mi")
+    XCTAssertEqual(lengthArray.dimensionalDescription, "L")
+  }
 }


### PR DESCRIPTION
This PR fixes #2.

All unitDescription logic was moved to unitDescription, and description calls unitDescription to get the unit description.

This PR also adds a very small and simple test to verify the fix.